### PR TITLE
Enable to use `permits` in controllers with namespace

### DIFF
--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -4,7 +4,7 @@ module AbstractController
       def send_action(method_name, *args)
         return send method_name, *args unless args.empty?
 
-        target_model_name = self.class.name.sub(/Controller$/, '').singularize.underscore.to_sym
+        target_model_name = self.class.name.sub(/.+::/, '').sub(/Controller$/, '').singularize.underscore.to_sym
         permitted_attributes = self.class.instance_variable_get '@permitted_attributes'
         values = method(method_name).parameters.reject {|type, _| type == :block }.map do |type, key|
           params.require key if type == :req

--- a/spec/controllers/strong_parameters_spec.rb
+++ b/spec/controllers/strong_parameters_spec.rb
@@ -13,4 +13,16 @@ if Rails::VERSION::MAJOR >= 4
       it { expect { post :create, :store => {name: 'Tatsu-zine', url: 'http://tatsu-zine.com'} }.to change(Store, :count).by(1) }
     end
   end
+
+  describe Admin::BooksController do
+    context "this controller doesn't permit price of new book" do
+      describe 'POST create' do
+        before { post :create, :book => {title: 'naruhoUnix', price: 30} }
+
+        it 'should not save price of the book' do
+          expect(Book.last.price).to be_nil
+        end
+      end
+    end
+  end
 end

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -16,6 +16,10 @@ ActionArgsTestApp::Application.routes.draw do
   resources :authors
   resources :books
   resources :stores
+
+  namespace :admin do
+    resources :books
+  end
 end
 
 # models
@@ -69,6 +73,16 @@ if Rails::VERSION::MAJOR >= 4
     def create(store)
       @store = Store.create! store
       render text: @store.name
+    end
+  end
+  module Admin
+    class BooksController < ::ApplicationController
+      permits :title
+
+      def create(book)
+        @book = Book.create! book
+        render text: @book.title
+      end
     end
   end
 end


### PR DESCRIPTION
I implemented folllowing admin function with using action_args and rails3:
#### config/routes.rb

``` ruby
namespace :admin do
  resources :articles
end
```
#### app/controllres/admin/articles_controller.rb

``` ruby
module Admin
  class ArticlesController < ApplicationController
    permits :title, :body
    def create article
      # default create action generated by scaffold
    end
  end
end
```

But, the `permits` method is not worked because `class_name` on here is `Admin::ArticlesController`, thus `Admin::Article` is called as model name.

This commit reduces namespace of controller when detecting the model name.
