### PR TITLE
Check `params` is defined

### DIFF
--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -3,6 +3,7 @@ module AbstractController
     if defined? ActionController::StrongParameters
       def send_action(method_name, *args)
         return send method_name, *args unless args.empty?
+        return send method_name, *args unless defined?(params)
 
         method_parameters = method(method_name).parameters
         ActionArgs::ParamsHandler.strengthen_params!(self.class, method_parameters, params)
@@ -29,6 +30,7 @@ module AbstractController
     else
       def send_action(method_name, *args)
         return send method_name, *args unless args.empty?
+        return send method_name, *args unless defined?(params)
 
         values = ActionArgs::ParamsHandler.extract_method_arguments_from_params method(method_name).parameters, params
         send method_name, *values

--- a/spec/fake_app.rb
+++ b/spec/fake_app.rb
@@ -31,6 +31,19 @@ end
 class Store < ActiveRecord::Base
 end
 
+# mailers
+require "action_mailer/railtie"
+class UserMailer < ActionMailer::Base
+  def send_email_without_args
+    mail(
+      to:      'to@example.com',
+      from:    'from@example.com',
+      subject: 'Action Args!!!',
+      body:    'test'
+    )
+  end
+end
+
 # helpers
 module ApplicationHelper; end
 

--- a/spec/mailers/action_mailer_spec.rb
+++ b/spec/mailers/action_mailer_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe UserMailer do
+  describe '#send_email_without_args' do
+    it "should not raise NameError: undefined local variable or method `params' for ..." do
+      expect{ UserMailer.send_email_without_args }.to_not raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
`params` is not defined in some case, for example when using ActionMailer.

```
class UserMailer < ActionMailer::Base
  def send_email_without_args
    mail(
      to:      'to@example.com',
      from:    'from@example.com',
      subject: 'Action Args!!!',
      body:    'test'
    )
  end
end

UserMailer.send_email_without_args
#=> NameError: undefined local variable or method `params' for #<UserMailer:0x007f7f50f124b8>
       from /Users/fukayatsu/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/bundler/gems/action_args-b5a9d108778a/lib/action_args/abstract_controller.rb:8:in `send_action'
```
