### PR TITLE
allow optional params with strong_parameter

### DIFF
--- a/lib/action_args/params_handler.rb
+++ b/lib/action_args/params_handler.rb
@@ -44,7 +44,8 @@ module ActionArgs
         method_parameters = method(method_name).parameters
         method_parameters.each do |type, key|
           if (key == target_model_name) && permitted_attributes
-            params[key] = params.require(key).try :permit, *permitted_attributes
+            params.require(key) if %i[req keyreq].include?(type)
+            params[key] = params[key].try :permit, *permitted_attributes
           end
         end
       end

--- a/test/controllers/strong_parameters_test.rb
+++ b/test/controllers/strong_parameters_test.rb
@@ -8,6 +8,18 @@ class StoresControllerTest < ActionController::TestCase
     assert_equal tatsu_zine, assigns(:store)
   end
 
+  sub_test_case 'GET new' do
+    test 'without store parameter' do
+      get :new
+      assert 200, response.code
+    end
+    test 'with store parameter' do
+      get :new, :store => {name: 'Tatsu-zine'}
+      assert 200, response.code
+      assert_equal 'Tatsu-zine', assigns(:store).name
+    end
+  end
+
   test 'POST create' do
     store_count_was = Store.count
     post :create, :store => {name: 'Tatsu-zine', url: 'http://tatsu-zine.com'}

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -113,6 +113,11 @@ class StoresController < ApplicationController
     render text: @store.name
   end
 
+  def new(store = nil)
+    @store = Store.new store
+    render text: @store.name
+  end
+
   def create(store)
     @store = Store.create! store
     render text: @store.name


### PR DESCRIPTION
I want to set default value on new action such like ```GET /users/new?user[name]=kuboon``` but it requires user param every time because of current ```permits``` mechanism ignores :opt params.
