### PR TITLE
Support Rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ matrix:
     - rvm: 2.1.10
       gemfile: gemfiles/rails_50.gemfile
     - rvm: 2.0.0
+      gemfile: gemfiles/rails_51.gemfile
+    - rvm: 2.1.10
+      gemfile: gemfiles/rails_51.gemfile
+    - rvm: 2.0.0
       gemfile: gemfiles/rails_edge.gemfile
     - rvm: 2.1.10
       gemfile: gemfiles/rails_edge.gemfile
@@ -36,4 +40,5 @@ gemfile:
   - gemfiles/rails_41.gemfile
   - gemfiles/rails_42.gemfile
   - gemfiles/rails_50.gemfile
+  - gemfiles/rails_51.gemfile
   - gemfiles/rails_edge.gemfile

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+source 'https://rubygems.org'
+git_source(:github) do |repo_name|
+  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
+  "https://github.com/#{repo_name}.git"
+end
+
+gem 'rails', '~> 5.1.0.beta1'
+
+# FIXME: bundle from GH master until > 1.0.1 release
+gem 'rails-controller-testing', github: 'rails/rails-controller-testing'
+
+gemspec :path => '../'
+
+platforms :ruby do
+  gem 'sqlite3'
+end
+
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+end

--- a/lib/action_args/callbacks.rb
+++ b/lib/action_args/callbacks.rb
@@ -48,7 +48,7 @@ module ActionArgs
   end
 end
 
-if Rails.version > '5.1'
+if Rails.version >= '5.1'
   module ActiveSupport
     module Callbacks
       class CallTemplate

--- a/test/controllers/hooks_test.rb
+++ b/test/controllers/hooks_test.rb
@@ -13,8 +13,10 @@ class BooksControllerTest < ActionController::TestCase
       assert_equal @book, assigns(:book)
     end
 
-    test 'via String' do
-      assert assigns(:string_filter_executed)
+    if Rails.version < '5.1'
+      test 'via String' do
+        assert assigns(:string_filter_executed)
+      end
     end
 
     test 'via Proc' do

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -69,7 +69,9 @@ end
 class BooksController < ApplicationController
   before_action :set_book, only: :show
   before_action -> { @proc_filter_executed = true }, only: :show
-  before_action '@string_filter_executed = true', only: :show
+  if Rails.version < '5.1'
+    before_action '@string_filter_executed = true', only: :show
+  end
   around_action :benchmark_action
   before_action :omg
   skip_before_action :omg


### PR DESCRIPTION
This PR fixes Rails 5.1 support and tests for it.
Note that passing string to define callback is not supported since 5.1.