### PR TITLE
Enable to pass keyword arguments except model_name

### DIFF
--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -27,8 +27,8 @@ module ActionArgs
     #     end
     #   end
     #
-    def permits(*attributes, model_name: nil)
-      @permitted_attributes, @permitting_model_name = attributes, model_name
+    def permits(*attributes, model_name: nil, **kw_attributes)
+      @permitted_attributes, @permitting_model_name = attributes << kw_attributes, model_name
     end
   end
 end

--- a/test/controllers/strong_parameters_test.rb
+++ b/test/controllers/strong_parameters_test.rb
@@ -29,6 +29,15 @@ class StoresControllerTest < ActionController::TestCase
   end
 end
 
+class MoviesControllerTest < ActionController::TestCase
+  test 'POST create' do
+    movie_count_was = Movie.count
+    post :create, params: {movie: {title: 'Dr. No', actors_attributes: [{name: 'Bernard Lee'}]}}
+
+    assert_equal 1, Movie.count - movie_count_was
+  end
+end
+
 # this controller doesn't permit price of new book do
 class Admin::BooksControllerTest < ActionController::TestCase
   test 'POST create' do

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -21,6 +21,7 @@ ActionArgsTestApp::Application.routes.draw do
   resources :kw_books  # 2.0+ only
   resources :kw_keyreq_books  # 2.1+ only
   resources :stores
+  resources :movies
 
   namespace :admin do
     resources :accounts
@@ -34,6 +35,13 @@ end
 class Book < ActiveRecord::Base
 end
 class Store < ActiveRecord::Base
+end
+class Movie < ActiveRecord::Base
+  has_many :actors
+  accepts_nested_attributes_for :actors
+end
+class Actor < ActiveRecord::Base
+  belongs_to :movie
 end
 module Admin
   def self.table_name_prefix() 'admin_' end
@@ -108,6 +116,14 @@ class BooksController < ApplicationController
       raise '💣'
     end
 end
+class MoviesController < ApplicationController
+  permits :title, actors_attributes: [:name]
+
+  def create(movie)
+    @movie = Movie.create! movie
+    render plain: @movie.title
+  end
+end
 class StoresController < ApplicationController
   permits :name, :url
 
@@ -156,6 +172,8 @@ class CreateAllTables < ActiveRecord::VERSION::MAJOR >= 5 ? ActiveRecord::Migrat
     create_table(:books) {|t| t.string :title; t.integer :price}
     create_table(:stores) {|t| t.string :name; t.string :url}
     create_table(:admin_accounts) {|t| t.string :name}
+    create_table(:movies) {|t| t.string :title}
+    create_table(:actors) {|t| t.string :name; t.references :movie}
   end
 end
 


### PR DESCRIPTION
Hash except `model_name` can be passed as arguments of `permtis` before 2.2.0 . It broke at  82bf125812b77d33d6812331d7931e4bbf36fc3c .