### PR TITLE
Add license to gemspec

### DIFF
--- a/action_args.gemspec
+++ b/action_args.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Akira Matsuda']
   s.email       = ['ronnie@dio.jp']
   s.homepage    = 'http://asakusa.rubyist.net/'
+  s.license     = 'MIT'
   s.summary     = 'Controller action arguments parameterizer for Rails 4+ & Ruby 2.0+'
   s.description = 'Rails plugin gem that supports Merbish style controller action arguments.'
 


### PR DESCRIPTION
This PR adds license item to gemspec. This item is used as follows.

- Describing LICENSES on rubygems.org (https://rubygems.org/gems/action_args)
- List of licenses displayed by `bundle licenses` command

This will increase the opportunity for users to learn about license.