### PR TITLE
Use default parameter value in params without target_model_name's key

### DIFF
--- a/lib/action_args/params_handler.rb
+++ b/lib/action_args/params_handler.rb
@@ -51,7 +51,7 @@ module ActionArgs
         method_parameters.each do |type, key|
           if (key == target_model_name) && permitted_attributes
             params.require(key) if %i[req keyreq].include?(type)
-            params[key] = params[key].try :permit, *permitted_attributes
+            params[key] = params[key].try :permit, *permitted_attributes if params.key? key
           end
         end
       end

--- a/test/controllers/strong_parameters_test.rb
+++ b/test/controllers/strong_parameters_test.rb
@@ -13,6 +13,7 @@ class StoresControllerTest < ActionController::TestCase
     test 'without store parameter' do
       get :new
       assert 200, response.code
+      assert_equal Hash.new, assigns(:store_param)
     end
     test 'with store parameter' do
       get :new, params: {store: {name: 'Tatsu-zine'}}

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -132,7 +132,8 @@ class StoresController < ApplicationController
     render plain: @store.name
   end
 
-  def new(store = nil)
+  def new(store = {})
+    @store_param = store
     @store = Store.new store
     render plain: @store.name
   end


### PR DESCRIPTION
This resolves a problem that default parameter value of target_model_name is never used since set the key to nil always.