### PR TITLE
Check `params` is not nil

### DIFF
--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -6,7 +6,7 @@ module ActionArgs
   module AbstractControllerMethods
     def send_action(method_name, *args)
       return super unless args.empty?
-      return super unless defined?(params)
+      return super if !defined?(params) || params.nil?
 
       strengthen_params! method_name
       values = extract_method_arguments_from_params method_name

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -60,6 +60,15 @@ class UserMailer < ActionMailer::Base
       body:    'test'
     )
   end
+
+  def send_email_with_optional_args(subject = 'Action Args!!!')
+    mail(
+      to:      'to@example.com',
+      from:    'from@example.com',
+      subject: subject,
+      body:    'test'
+    )
+  end
 end
 
 # helpers

--- a/test/mailers/action_mailer_test.rb
+++ b/test/mailers/action_mailer_test.rb
@@ -6,4 +6,9 @@ class UserMailerTest < ActionMailer::TestCase
     #it should not raise NameError: undefined local variable or method `params' for ...
     assert UserMailer.send_email_without_args
   end
+
+  test '#send_email_with_optional_args' do
+    #it should not raise NoMethodError: undefined method for nil:NilClass
+    assert UserMailer.send_email_with_optional_args
+  end
 end


### PR DESCRIPTION
Fix #23
Relates #5

`params` can be `nil` In ActionMailer of Rails 5.1