### PR TITLE
Enable to use args named like strong parameters

### DIFF
--- a/test/params_handler/params_handler_test.rb
+++ b/test/params_handler/params_handler_test.rb
@@ -21,14 +21,32 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
       assert_equal ['1'], @controller.extract_method_arguments_from_params(:m)
     end
 
+    test '1 req with args named like strong parameters' do
+      def @controller.m(a_params) end
+
+      assert_equal ['1'], @controller.extract_method_arguments_from_params(:m)
+    end
+
     test '2 reqs' do
       def @controller.m(a, b) end
 
       assert_equal ['1', '2'], @controller.extract_method_arguments_from_params(:m)
     end
 
+    test '2 reqs with args named like strong parameters' do
+      def @controller.m(a_params, b_params) end
+
+      assert_equal ['1', '2'], @controller.extract_method_arguments_from_params(:m)
+    end
+
     test '1 opt with value' do
       def @controller.m(a = 'a') end
+
+      assert_equal ['1'], @controller.extract_method_arguments_from_params(:m)
+    end
+
+    test '1 opt with value with args named like strong parameters' do
+      def @controller.m(a_params = 'a') end
 
       assert_equal ['1'], @controller.extract_method_arguments_from_params(:m)
     end
@@ -111,6 +129,12 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
       assert_equal [a: '1'], @controller.extract_method_arguments_from_params(:m)
     end
 
+    test 'key with args named like strong parameters' do
+      def @controller.m(a_params: nil) end
+
+      assert_equal [a_params: '1'], @controller.extract_method_arguments_from_params(:m)
+    end
+
     test 'key, key without value' do
       def @controller.m(a: nil, x: 'x') end
 
@@ -125,6 +149,12 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
           assert_equal [a: '1'], @controller.extract_method_arguments_from_params(:m)
         end
 
+        test 'keyreq with args named like strong parameters' do
+          def @controller.m(a_params:) end
+
+          assert_equal [a_params: '1'], @controller.extract_method_arguments_from_params(:m)
+        end
+
         test 'keyreq, keyreq without value' do
           def @controller.m(a:, x:) end
 
@@ -136,7 +166,7 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
 
   sub_test_case 'strengthen_params!' do
     setup do
-      @params = ActionController::Parameters.new(x: '1', y: '2', foo: {a: 'a', b: 'b'}, bar: {a: 'a', b: 'b'}, baz: {a: 'a', b: 'b'}, hoge: {a: 'a', b: 'b'}, fuga: {a: 'a', b: 'b'})
+      @params = ActionController::Parameters.new(x: '1', y: '2', foo: {a: 'a', b: 'b'}, bar: {a: 'a', b: 'b'}, baz: {a: 'a', b: 'b'}, hoge: {a: 'a', b: 'b'}, fuga: {a: 'a', b: 'b'}, foo_foo: {a: 'a', b: 'b'}, hoge_hoge: {a: 'a', b: 'b'}, fuga_fuga: {a: 'a', b: 'b'})
     end
 
     def execute_strengthen_params!(controller)
@@ -151,6 +181,14 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
       assert @params[:foo].permitted?
       assert_not_nil @params[:foo][:a]
       assert_not_nil @params[:foo][:b]
+    end
+
+    test 'requiring via :req, permitting all scalars with args named like strong parameters' do
+      execute_strengthen_params! FooFooController ||= Class.new(ApplicationController) { permits :a, :b; def a(foo_foo_params) end }
+
+      assert @params[:foo_foo].permitted?
+      assert_not_nil @params[:foo_foo][:a]
+      assert_not_nil @params[:foo_foo][:b]
     end
 
     test 'requiring via :req, not permitting all scalars' do
@@ -175,6 +213,14 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
       assert_not_nil @params[:hoge][:b]
     end
 
+    test 'requiring via :opt, permitting all scalars with args named like strong parameters' do
+      execute_strengthen_params! HogeHogeController ||= Class.new(ApplicationController) { permits :a, :b; def a(hoge_hoge_params = {}) end }
+
+      assert @params[:hoge_hoge].permitted?
+      assert_not_nil @params[:hoge_hoge][:a]
+      assert_not_nil @params[:hoge_hoge][:b]
+    end
+
     test 'requiring via :key, permitting all scalars' do
       execute_strengthen_params! FugaController ||= Class.new(ApplicationController) { permits :a, :b; def a(fuga: {}) end }
 
@@ -183,8 +229,24 @@ class ActionArgs::ParamsHandlerTest < ActiveSupport::TestCase
       assert_not_nil @params[:fuga][:b]
     end
 
+    test 'requiring via :key, permitting all scalars with args named like strong parameters' do
+      execute_strengthen_params! FugaFugaController ||= Class.new(ApplicationController) { permits :a, :b; def a(fuga_fuga_params: {}) end }
+
+      assert @params[:fuga_fuga].permitted?
+      assert_not_nil @params[:fuga_fuga][:a]
+      assert_not_nil @params[:fuga_fuga][:b]
+    end
+
     test '"model_name" option' do
       execute_strengthen_params! PiyoController ||= Class.new(ApplicationController) { permits :a, :b, model_name: 'Foo'; def a(foo) end }
+
+      assert @params[:foo].permitted?
+      assert_not_nil @params[:foo][:a]
+      assert_not_nil @params[:foo][:b]
+    end
+
+    test '"model_name" option with args named like strong parameters' do
+      execute_strengthen_params! PiyoPiyoController = Class.new(ApplicationController) { permits :a, :b, model_name: 'Foo'; def a(foo_params) end }
 
       assert @params[:foo].permitted?
       assert_not_nil @params[:foo][:a]


### PR DESCRIPTION
I supported action method args named like strong parameters.
It can use like this.

```
def create(user_params)
  User.create(user_params)
  ...
end
```

This change is useful for introducing action_args gem to rails application which already uses strong parameters.
Required change is be smaller.

```
class UsersController < ApplicationController
  def create
    User.create(user_params)
    ...
  end
  
  private

  def user_params
    # permit some parameters..
  end
end
```

Before:  
It requires

- Delete `user_params` method
- Add args to action method
- Change variable names used in action method

```
class UsersController < ApplicationController
  def create(user)
    User.create(user)
    ...
  end
end
```

After:  
only 2 changes are required.

- Delete `user_params` method
- Add args to action method

```
class UsersController < ApplicationController
  def create(user_params)
    User.create(user_params)
    ...
  end
end
```