### PR TITLE
Fix keyword arguments warning from callbacks

### DIFF
--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -111,7 +111,7 @@ class BooksController < ApplicationController
   end
 
   private
-    def set_book(id)
+    def set_book(id:)
       @book = Book.find(id)
     end
 


### PR DESCRIPTION
In order to properly provide keyword arguments, we need to override `#make_lambda` instead of `#expand`.

```
/home/r7kamura/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/activesupport-6.1.3.2/lib/active_support/callbacks.rb:427: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/r7kamura/ghq/github.com/asakusarb/action_args/test/fake_app.rb:114: warning: The called method `set_book' is defined here
```