### PR TITLE
Add a scaffold_controller template file for API-only application 

### DIFF
--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -1,0 +1,59 @@
+class <%= controller_class_name %>Controller < ApplicationController
+<% if defined? ActionController::StrongParameters -%>
+  permits <%= attributes.map {|a| ":#{a.name}" }.join(', ') %>
+
+<% end -%>
+  # GET <%= route_url %>
+  def index
+    @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+  end
+
+  # GET <%= route_url %>/1
+  def show(id)
+    @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
+  end
+
+  # GET <%= route_url %>/new
+  def new
+    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
+  end
+
+  # GET <%= route_url %>/1/edit
+  def edit(id)
+    @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
+  end
+
+  # POST <%= route_url %>
+  def create(<%= singular_table_name %>)
+    @<%= singular_table_name %> = <%= orm_class.build(class_name, singular_table_name) %>
+
+    if @<%= orm_instance.save %>
+      redirect_to @<%= singular_table_name %>, notice: '<%= human_name %> was successfully created.'
+    else
+      render :new
+    end
+  end
+
+  # PUT <%= route_url %>/1
+  def update(id, <%= singular_table_name %>)
+    @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
+
+<% if orm_instance.respond_to? :update -%>
+    if @<%= orm_instance.update(singular_table_name) %>
+<% else -%>
+    if @<%= orm_instance.update_attributes(singular_table_name) %>
+<% end -%>
+      redirect_to @<%= singular_table_name %>, notice: '<%= human_name %> was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  # DELETE <%= route_url %>/1
+  def destroy(id)
+    @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
+    @<%= orm_instance.destroy %>
+
+    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
+  end
+end

--- a/lib/generators/rails/templates/api_controller.rb
+++ b/lib/generators/rails/templates/api_controller.rb
@@ -6,21 +6,15 @@ class <%= controller_class_name %>Controller < ApplicationController
   # GET <%= route_url %>
   def index
     @<%= plural_table_name %> = <%= orm_class.all(class_name) %>
+
+    render json: <%= "@#{plural_table_name}" %>
   end
 
   # GET <%= route_url %>/1
   def show(id)
     @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
-  end
 
-  # GET <%= route_url %>/new
-  def new
-    @<%= singular_table_name %> = <%= orm_class.build(class_name) %>
-  end
-
-  # GET <%= route_url %>/1/edit
-  def edit(id)
-    @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
+    render json: <%= "@#{singular_table_name}" %>
   end
 
   # POST <%= route_url %>
@@ -28,9 +22,9 @@ class <%= controller_class_name %>Controller < ApplicationController
     @<%= singular_table_name %> = <%= orm_class.build(class_name, singular_table_name) %>
 
     if @<%= orm_instance.save %>
-      redirect_to @<%= singular_table_name %>, notice: '<%= human_name %> was successfully created.'
+      render json: <%= "@#{singular_table_name}" %>, status: :created, location: <%= "@#{singular_table_name}" %>
     else
-      render :new
+      render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
     end
   end
 
@@ -43,9 +37,9 @@ class <%= controller_class_name %>Controller < ApplicationController
 <% else -%>
     if @<%= orm_instance.update_attributes(singular_table_name) %>
 <% end -%>
-      redirect_to @<%= singular_table_name %>, notice: '<%= human_name %> was successfully updated.'
+      render json: <%= "@#{singular_table_name}" %>
     else
-      render :edit
+      render json: <%= "@#{orm_instance.errors}" %>, status: :unprocessable_entity
     end
   end
 
@@ -53,7 +47,5 @@ class <%= controller_class_name %>Controller < ApplicationController
   def destroy(id)
     @<%= singular_table_name %> = <%= orm_class.find(class_name, 'id') %>
     @<%= orm_instance.destroy %>
-
-    redirect_to <%= index_helper %>_url, notice: <%= "'#{human_name} was successfully destroyed.'" %>
   end
 end


### PR DESCRIPTION
Hi! Thank you for a cool gem 😆 

I found that when I try to do `rails generate scaffold` with an application created with `rails new my_api --api`, I get the following error.

```sh
      invoke  action_args_scaffold_controller
Could not find "api_controller.rb" in any of your source paths. Your current source paths are:
/bundle/ruby/3.0.0/gems/action_args-2.6.0/lib/generators/rails/templates
```

So, I added the api_controller.rb template file like Rails itself.
https://github.com/rails/rails/blob/v5.0.7.2/railties/lib/rails/generators/rails/scaffold_controller/templates/api_controller.rb

Please check my changes and merge them if you like it. Thanks!