### PR TITLE
Fix monkey-patch AS::Callbacks::CallTemplate::MethodCall

### DIFF
--- a/lib/action_args/callbacks.rb
+++ b/lib/action_args/callbacks.rb
@@ -18,9 +18,7 @@ module ActionArgs
                   target.send(@method_name, *arguments, &block)
                 end
               else
-                lambda do |target, value, &block|
-                  target.send(@method_name, &block)
-                end
+                target.send(@method_name, &block)
               end
             end
           end


### PR DESCRIPTION
closes #33
refs caae81123702a4ea5b29f1af4159c792ecbcb825

`lambda` block is duplicated (nested), so the inner one is not required.

https://github.com/asakusarb/action_args/blob/dea67bd3540ab830ae45b73b8dd96187765646be/lib/action_args/callbacks.rb#L11

https://github.com/asakusarb/action_args/blob/dea67bd3540ab830ae45b73b8dd96187765646be/lib/action_args/callbacks.rb#L21