### PR TITLE
Fix argument error on Ruby 3.2/ ActionMailer keyword argument.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ platforms :jruby do
 end
 
 gem 'nokogiri', RUBY_VERSION < '2.1' ? '~> 1.6.0' : '>= 1.7'
+gem 'loofah', RUBY_VERSION < '2.5' ? '~> 2.20.0' : '>= 2.20'
 
 gem 'selenium-webdriver' if rails_version >= '6.1'
 

--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -5,8 +5,16 @@ using ActionArgs::ParamsHandler
 
 module ActionArgs
   module AbstractControllerMethods
-    def send_action(method_name, *args, **kwargs)
-      return super unless (args.empty? && kwargs.empty?)
+    def send_action(method_name, *args)
+      unless args.empty?
+        kwargs = args.extract_options!
+        if kwargs.any?
+          return super(method_name, *args, **kwargs)
+        else
+          return super
+        end
+      end
+
       return super if !defined?(params) || params.nil?
 
       strengthen_params! method_name

--- a/lib/action_args/abstract_controller.rb
+++ b/lib/action_args/abstract_controller.rb
@@ -5,8 +5,8 @@ using ActionArgs::ParamsHandler
 
 module ActionArgs
   module AbstractControllerMethods
-    def send_action(method_name, *args)
-      return super unless args.empty?
+    def send_action(method_name, *args, **kwargs)
+      return super unless (args.empty? && kwargs.empty?)
       return super if !defined?(params) || params.nil?
 
       strengthen_params! method_name

--- a/test/controllers/kwargs_controller_test.rb
+++ b/test/controllers/kwargs_controller_test.rb
@@ -28,5 +28,12 @@ class KwBooksControllerTest < ActionController::TestCase
       assert_equal '1', body[:page]
       assert_equal 'Rails', body[:q]
     end
+
+    test 'with kwreq' do
+      get :show, params: {id: 1}
+      body = eval response.body
+      assert_equal '1', body[:id]
+      assert_equal 'nari', body[:author_name]
+    end
   end
 end

--- a/test/fake_app.rb
+++ b/test/fake_app.rb
@@ -75,6 +75,15 @@ class UserMailer < ActionMailer::Base
       body:    'test'
     )
   end
+
+  def send_email_with_keyreq(subject:)
+    mail(
+      to:      'to@example.com',
+      from:    'from@example.com',
+      subject: subject,
+      body:    'test'
+    )
+  end
 end
 
 # helpers

--- a/test/kwargs_controllers.rb
+++ b/test/kwargs_controllers.rb
@@ -7,4 +7,11 @@ class KwBooksController < ApplicationController
   def index(author_name, page: '1', q: nil)
     render plain: {author_name: author_name, page: page, q: q}.inspect
   end
+
+  def show(id:)
+    db = {'1' => 'nari'}
+    author_name = db.fetch(id)
+
+    render plain: {id: id, author_name: author_name}.inspect
+  end
 end

--- a/test/mailers/action_mailer_test.rb
+++ b/test/mailers/action_mailer_test.rb
@@ -12,4 +12,8 @@ class UserMailerTest < ActionMailer::TestCase
     #it should not raise NoMethodError: undefined method for nil:NilClass
     assert UserMailer.send_email_with_optional_args
   end
+
+  test '#send_email_with_keyreq' do
+    assert UserMailer.send_email_with_keyreq(subject: 'Action Args!!!')
+  end
 end


### PR DESCRIPTION
Hi. Thanks a lot this nice gem.

I got some errors on my project while upgrading Ruby to 3.2.x.

Ruby 3.2's `super` recognize kwargs only if declared arguments separately for ActionMailer method call. Or we get error below:
```
ArgumentError: wrong number of arguments (given 1, expected 0; required keyword: subject)
```

---------

BTW https://github.com/asakusarb/action_args/commit/5b4433796893f76785018a017faaa780d7bd5849 is just adding a regression test case.

I'll drop commit if the case is not needed.